### PR TITLE
Fix out-of-bounds read caused by off-by-one error

### DIFF
--- a/cent.c
+++ b/cent.c
@@ -2,7 +2,7 @@
 #include<stdlib.h>
 void ways(int a[],int value,int size,int no[])
 {
-	if (size <-1|| value <0)
+	if (size <= -1|| value <0)
 		return ;
 	if (value==0)
 	{	


### PR DESCRIPTION
This bug was automatically found by executing the program with [Safe Sulong](https://github.com/graalvm/sulong/blob/master/docs/SAFE-SULONG.md).